### PR TITLE
fix: ensure `BlzGetTriggerPlayerMetaKey` returns `MetaKey`

### DIFF
--- a/WCSharp.Api/Base/Common.cs
+++ b/WCSharp.Api/Base/Common.cs
@@ -6261,7 +6261,7 @@ namespace WCSharp.Api
 		/// @CSharpLua.Template = "BlzGetTriggerPlayerKey()"
 		public static extern oskeytype BlzGetTriggerPlayerKey();
 		/// @CSharpLua.Template = "BlzGetTriggerPlayerMetaKey()"
-		public static extern int BlzGetTriggerPlayerMetaKey();
+		public static extern MetaKey BlzGetTriggerPlayerMetaKey();
 		/// @CSharpLua.Template = "BlzGetTriggerPlayerIsKeyDown()"
 		public static extern bool BlzGetTriggerPlayerIsKeyDown();
 		/// @CSharpLua.Template = "BlzEnableCursor({0})"


### PR DESCRIPTION
Align return type of `BlzGetTriggerPlayerMetaKey` to match `BlzTriggerRegisterPlayerKeyEvent` parameter expectations: https://github.com/Orden4/WCSharp/blob/2a66d9d0e071cafcdfdab5b1b1738bf2268a7168/WCSharp.Api/Base/Common.cs#L6260